### PR TITLE
prevents failure due to missing environment

### DIFF
--- a/cmd/ejson2env/env_test.go
+++ b/cmd/ejson2env/env_test.go
@@ -40,6 +40,42 @@ func TestLoadSecrets(t *testing.T) {
 
 }
 
+func TestLoadNoEnvSecrets(t *testing.T) {
+
+	rawValues, err := ReadSecrets("test2.ejson", "./key", TestKeyValue)
+	if nil != err {
+		t.Fatal(err)
+	}
+
+	_, err = ExtractEnv(rawValues)
+	if errNoEnv != err {
+		t.Fatal(err)
+	}
+
+	if isFailure(err) {
+		t.Fatalf("shouldn't have caused a failure: %s", err)
+	}
+
+}
+
+func TestLoadBadEnvSecrets(t *testing.T) {
+
+	rawValues, err := ReadSecrets("test3.ejson", "./key", TestKeyValue)
+	if nil != err {
+		t.Fatal(err)
+	}
+
+	_, err = ExtractEnv(rawValues)
+	if errEnvNotMap != err {
+		t.Fatal(err)
+	}
+
+	if isFailure(err) {
+		t.Fatalf("shouldn't have caused a failure: %s", err)
+	}
+
+}
+
 func TestInvalidEnvironments(t *testing.T) {
 	testGood := map[string]interface{}{
 		"environment": map[string]interface{}{

--- a/cmd/ejson2env/key_test.go
+++ b/cmd/ejson2env/key_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestReadKey(t *testing.T) {
+	buffer := bytes.NewBufferString(TestKeyValue)
+	value, err := readKey(buffer)
+
+	if nil != err {
+		t.Errorf("shouldn't have returned an error, return: %s", err)
+	}
+
+	if value != TestKeyValue {
+		t.Errorf("value does not match expected:\nvalue: \"%s\"\nexpected: \"%s\"", value, TestKeyValue)
+	}
+}

--- a/cmd/ejson2env/main.go
+++ b/cmd/ejson2env/main.go
@@ -13,23 +13,6 @@ func fail(err error) {
 	os.Exit(1)
 }
 
-// exportSecrets wraps the read, extract, and export steps. Returns
-// an error if any step fails.
-func exportSecrets(filename, keyDir, privateKey string) error {
-	secrets, err := ReadSecrets(filename, keyDir, privateKey)
-	if nil != err {
-		return (fmt.Errorf("could not load ejson file: %s", err))
-	}
-
-	envValues, err := ExtractEnv(secrets)
-	if nil != err {
-		return fmt.Errorf("could not load environment from file: %s", err)
-	}
-
-	ExportEnv(os.Stdout, envValues)
-	return nil
-}
-
 func main() {
 	app := cli.NewApp()
 	app.Usage = "get environment variables from ejson files"

--- a/cmd/ejson2env/secrets_test.go
+++ b/cmd/ejson2env/secrets_test.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReadSecrets(t *testing.T) {
+	var err error
+
+	_, err = ReadSecrets("bad.ejson", "./key", TestKeyValue)
+	if nil == err {
+		t.Fatal("failed to fail when loading a broken ejson file")
+	}
+	if !strings.Contains(err.Error(), "no such file or directory") {
+		t.Errorf("error should be \"no such file or directory\": %s", err)
+	}
+}

--- a/cmd/ejson2env/test2.ejson
+++ b/cmd/ejson2env/test2.ejson
@@ -1,0 +1,3 @@
+{
+    "_public_key": "795e671066eef17025c816b6d7c4f5c658b191cfaa31baca69963d761606415c"
+}

--- a/cmd/ejson2env/test3.ejson
+++ b/cmd/ejson2env/test3.ejson
@@ -1,0 +1,4 @@
+{
+    "_public_key": "795e671066eef17025c816b6d7c4f5c658b191cfaa31baca69963d761606415c",
+    "environment": "EJ[1:vLCXRxBXJjdT+w8gSPlM45F3HdykWvUdNAeXLJ51GQ4=:BxQq4GdlfxXvCHs0xall8LKesFVjEStm:K2GhhrTy4Tvhb2w0d3RyR9Y/Gg==]"
+}


### PR DESCRIPTION
This change fixes an issue that occurred in production with secrets.ejson that do not have an environment block. This change ignores non-existent and non-map[string]string environment fields.