### PR TITLE
Please be quiet!

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.11-alpine AS builder
+WORKDIR /go/src/github.com/Shopify/ejson2env
+COPY . .
+RUN go install -v github.com/Shopify/ejson2env/cmd/ejson2env
+
+FROM scratch
+COPY --from=builder /go/bin/ejson2env /
+WORKDIR /tmp
+ENTRYPOINT ["/ejson2env"]

--- a/cmd/ejson2env/env.go
+++ b/cmd/ejson2env/env.go
@@ -46,3 +46,11 @@ func ExportEnv(w io.Writer, values map[string]string) {
 		fmt.Fprintf(w, "export %s=%s\n", key, shell.Escape(value))
 	}
 }
+
+// ExportQuiet writes the passed environment values to the passed
+// io.Writer without the "export " string prepended
+func ExportQuiet(w io.Writer, values map[string]string) {
+	for key, value := range values {
+		fmt.Fprintf(w, "%s=%s\n", key, shell.Escape(value))
+	}
+}

--- a/cmd/ejson2env/env.go
+++ b/cmd/ejson2env/env.go
@@ -48,7 +48,7 @@ func ExportEnv(w io.Writer, values map[string]string) {
 }
 
 // ExportQuiet writes the passed environment values to the passed
-// io.Writer without the "export " string prepended
+// io.Writer in %s=%s format.
 func ExportQuiet(w io.Writer, values map[string]string) {
 	for key, value := range values {
 		fmt.Fprintf(w, "%s=%s\n", key, shell.Escape(value))

--- a/cmd/ejson2env/main.go
+++ b/cmd/ejson2env/main.go
@@ -42,6 +42,12 @@ func main() {
 		keydir := c.String("keydir")
 		quiet := c.Bool("quiet")
 		var userSuppliedPrivateKey string
+		// select the ExportFunction to use
+		exportFunc := ExportEnv
+		if quiet {
+			exportFunc = ExportQuiet
+		}
+
 		if c.Bool("key-from-stdin") {
 			var err error
 			userSuppliedPrivateKey, err = readKey(os.Stdin)
@@ -58,7 +64,7 @@ func main() {
 			fail(fmt.Errorf("no secrets.ejson filename passed"))
 		}
 
-		if err := exportSecrets(filename, keydir, userSuppliedPrivateKey, quiet); nil != err {
+		if err := exportSecrets(filename, keydir, userSuppliedPrivateKey, exportFunc); nil != err {
 			fail(err)
 		}
 	}

--- a/cmd/ejson2env/main.go
+++ b/cmd/ejson2env/main.go
@@ -38,10 +38,11 @@ func main() {
 
 	app.Action = func(c *cli.Context) {
 		var filename string
+		var userSuppliedPrivateKey string
 
 		keydir := c.String("keydir")
 		quiet := c.Bool("quiet")
-		var userSuppliedPrivateKey string
+
 		// select the ExportFunction to use
 		exportFunc := ExportEnv
 		if quiet {

--- a/cmd/ejson2env/main.go
+++ b/cmd/ejson2env/main.go
@@ -30,13 +30,17 @@ func main() {
 			Name:  "key-from-stdin",
 			Usage: "Read the private key from STDIN",
 		},
+		cli.BoolFlag{
+			Name:  "quiet, q",
+			Usage: "Suppress export statement",
+		},
 	}
 
 	app.Action = func(c *cli.Context) {
 		var filename string
 
 		keydir := c.String("keydir")
-
+		quiet := c.Bool("quiet")
 		var userSuppliedPrivateKey string
 		if c.Bool("key-from-stdin") {
 			var err error
@@ -54,7 +58,7 @@ func main() {
 			fail(fmt.Errorf("no secrets.ejson filename passed"))
 		}
 
-		if err := exportSecrets(filename, keydir, userSuppliedPrivateKey); nil != err {
+		if err := exportSecrets(filename, keydir, userSuppliedPrivateKey, quiet); nil != err {
 			fail(err)
 		}
 	}

--- a/cmd/ejson2env/secrets.go
+++ b/cmd/ejson2env/secrets.go
@@ -37,7 +37,7 @@ func isFailure(err error) bool {
 
 // exportSecrets wraps the read, extract, and export steps. Returns
 // an error if any step fails.
-func exportSecrets(filename, keyDir, privateKey string) error {
+func exportSecrets(filename, keyDir, privateKey string, quiet bool) error {
 	secrets, err := ReadSecrets(filename, keyDir, privateKey)
 	if nil != err {
 		return fmt.Errorf("could not load ejson file: %s", err)
@@ -48,6 +48,10 @@ func exportSecrets(filename, keyDir, privateKey string) error {
 		return fmt.Errorf("could not load environment from file: %s", err)
 	}
 
-	ExportEnv(os.Stdout, envValues)
+	if quiet {
+		ExportQuiet(os.Stdout, envValues)
+	} else {
+		ExportEnv(os.Stdout, envValues)
+	}
 	return nil
 }


### PR DESCRIPTION
I've been using a custom ejson2env Docker container to populate a systemd [`EnvironmentFile`](https://www.freedesktop.org/software/systemd/man/systemd.exec.html) which is described as:

> Similar to `Environment=` but reads the environment variables from a text file. The text file should contain new-line-separated variable assignments.

Ref the following example:

```
$ docker run --rm \
-v /var/bullseye/ejson/keys:/opt/ejson/keys:ro \
-v /var/bullseye/services:/tmp:ro \
-w /tmp \
gcr.io/trusted-builds/ejson2env -q datadog.ejson > /var/bullseye/services/datadog.env

$ cat /var/bullseye/services/datadog.env
DATADOG_API_KEY=lolol
FOO=BAR
```

Here's the Dockerfile and support for the `--quiet` flag