### PR TITLE
Add test for env value with leading underscore

### DIFF
--- a/cmd/ejson2env/env_test.go
+++ b/cmd/ejson2env/env_test.go
@@ -65,6 +65,24 @@ func TestLoadBadEnvSecrets(t *testing.T) {
 
 }
 
+func TestLoadUnderscoreEnvSecrets(t *testing.T) {
+
+	rawValues, err := ReadSecrets("../../testdata/test4.ejson", "./key", TestKeyValue)
+	if nil != err {
+		t.Fatal(err)
+	}
+
+	envValues, err := ExtractEnv(rawValues)
+	if nil != err {
+		t.Fatal(err)
+	}
+
+	if "test value" != envValues["_test_key"] {
+		t.Error("Failed to decrypt")
+	}
+
+}
+
 func TestInvalidEnvironments(t *testing.T) {
 	testGood := map[string]interface{}{
 		"environment": map[string]interface{}{

--- a/testdata/test4.ejson
+++ b/testdata/test4.ejson
@@ -1,0 +1,6 @@
+{
+    "_public_key": "795e671066eef17025c816b6d7c4f5c658b191cfaa31baca69963d761606415c",
+    "environment": {
+        "_test_key": "test value"
+    }
+}


### PR DESCRIPTION
This adds a test to document how leading underscores are handled in environment keys.

Given the following EJSON, containing an unencrypted `_test_key`:

```json
{
    "_public_key": "795e671066eef17025c816b6d7c4f5c658b191cfaa31baca69963d761606415c",
    "environment": {
        "_test_key": "test value"
    }
}
```

the value `test value` is extracted as `_test_key`, without affecting the leading underscore.