### PR TITLE
Remove Codecov from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,3 @@ go:
 
 script:
   - go test -race -coverprofile=coverage.txt -covermode=atomic
-
-after_success:
-  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Build Status](https://travis-ci.org/Shopify/ejson2env.svg?branch=master)](https://travis-ci.org/Shopify/ejson2env)
-[![codecov](https://codecov.io/gh/Shopify/ejson2env/branch/master/graph/badge.svg)](https://codecov.io/gh/Shopify/ejson2env)
 [![Go Report Card](https://goreportcard.com/badge/github.com/Shopify/ejson2env)](https://goreportcard.com/report/github.com/Shopify/ejson2env)
 
 # ejson2env


### PR DESCRIPTION
This PR removes Codecov from Travis-CI as its use is deprecated.