### PR TITLE
ffi: bump to latest

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GEM
       ffi (~> 1.0, >= 1.0.11)
     clamp (1.0.1)
     dotenv (2.5.0)
-    ffi (1.9.25)
+    ffi (1.15.4)
     fpm (1.10.2)
       arr-pm (~> 0.0.10)
       backports (>= 2.6.2)


### PR DESCRIPTION
The version of ffi used by this repo is outdated and doesn't have support for M1 Macs when building natively. The latest version of ffi is compatible with all of the dependency specifications, though, so we can just bump this one file in the Gemfile.lock.