### PR TITLE
fpm: latest

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,46 +1,42 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    arr-pm (0.0.10)
+    arr-pm (0.0.11)
       cabin (> 0)
-    backports (3.11.4)
+    backports (3.21.0)
     cabin (0.9.0)
-    childprocess (0.9.0)
-      ffi (~> 1.0, >= 1.0.11)
     clamp (1.0.1)
-    dotenv (2.5.0)
-    ffi (1.15.4)
-    fpm (1.10.2)
-      arr-pm (~> 0.0.10)
+    dotenv (2.7.6)
+    fpm (1.13.1)
+      arr-pm (~> 0.0.11)
       backports (>= 2.6.2)
       cabin (>= 0.6.0)
-      childprocess
       clamp (~> 1.0.0)
-      ffi
-      json (>= 1.7.7, < 2.0)
+      git (>= 1.3.0, < 2.0)
+      json (>= 1.7.7, < 3.0)
       pleaserun (~> 0.0.29)
-      ruby-xz (~> 0.2.3)
+      rexml
       stud
+    git (1.9.1)
+      rchardet (~> 1.8)
     hpricot (0.8.6)
     insist (1.0.0)
-    io-like (0.3.0)
-    json (1.8.6)
+    json (2.6.1)
     mustache (0.99.8)
-    pleaserun (0.0.30)
+    pleaserun (0.0.32)
       cabin (> 0)
       clamp
       dotenv
       insist
       mustache (= 0.99.8)
       stud
+    rchardet (1.8.0)
     rdiscount (2.2.0.2)
+    rexml (3.2.5)
     ronn (0.7.3)
       hpricot (>= 0.8.2)
       mustache (>= 0.7.0)
       rdiscount (>= 1.5.8)
-    ruby-xz (0.2.3)
-      ffi (~> 1.9)
-      io-like (~> 0.3)
     stud (0.0.23)
 
 PLATFORMS


### PR DESCRIPTION
The older fpm we're using crashes on M1 Macs. The latest version doesn't.