### PR TITLE
Add linux-arm64 binary

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ $ git push -u <your username> <the name of your branch>
 The release process is somewhat awkward right now. `ejson2env` is released in
 four ways:
 
-* `linux-amd64`, `darwin-amd64`, `darwin-arm64`
+* `linux-amd64`, `linux-arm64`, `darwin-amd64`, `darwin-arm64`
 * rubygem;
 * `.deb` package; and
 * homebrew formula

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ BUNDLE_EXEC=bundle exec
 
 default: all
 all: gem deb
-binaries: build/bin/linux-amd64 build/bin/darwin-universal build/bin/freebsd-amd64
+binaries: build/bin/linux-amd64 build/bin/linux-arm64 build/bin/darwin-universal build/bin/freebsd-amd64
 gem: $(GEM)
 deb: $(DEB)
 man: $(MANFILES)
@@ -26,6 +26,13 @@ build/man/%.gz: man/%.ronn
 build/bin/linux-amd64: $(GOFILES)
 	mkdir -p "$(@D)"
 	GOOS=linux GOARCH=amd64 go build \
+	-ldflags '-s -w -X main.version="$(VERSION)"' \
+	-o "$@" \
+	"$(PACKAGE)/cmd/$(NAME)"
+
+build/bin/linux-arm64: $(GOFILES)
+	mkdir -p "$(@D)"
+	GOOS=linux GOARCH=arm64 go build \
 	-ldflags '-s -w -X main.version="$(VERSION)"' \
 	-o "$@" \
 	"$(PACKAGE)/cmd/$(NAME)"

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ $(GEM): rubygem/$(NAME)-$(VERSION).gem
 rubygem/$(NAME)-$(VERSION).gem: \
 	rubygem/lib/$(NAME)/version.rb \
 	rubygem/build/linux-amd64/ejson2env \
+	rubygem/build/linux-arm64/ejson2env \
 	rubygem/LICENSE.txt \
 	rubygem/build/darwin-universal/ejson2env \
 	rubygem/build/freebsd-amd64/ejson2env \
@@ -82,6 +83,10 @@ rubygem/build/darwin-universal/ejson2env: build/bin/darwin-universal
 	cp -a "$<" "$@"
 
 rubygem/build/linux-amd64/ejson2env: build/bin/linux-amd64
+	mkdir -p $(@D)
+	cp -a "$<" "$@"
+
+rubygem/build/linux-arm64/ejson2env: build/bin/linux-arm64
 	mkdir -p $(@D)
 	cp -a "$<" "$@"
 

--- a/rubygem/MANIFEST
+++ b/rubygem/MANIFEST
@@ -1,6 +1,7 @@
 bin/ejson2env
 build/darwin-universal/ejson2env
 build/linux-amd64/ejson2env
+build/linux-arm64/ejson2env
 build/freebsd-amd64/ejson2env
 man/ejson2env.1.gz
 ejson2env.gemspec

--- a/rubygem/bin/ejson2env
+++ b/rubygem/bin/ejson2env
@@ -3,6 +3,7 @@ platform = `uname -sm`
 
 dir = case platform
       when /^Darwin/    ; "darwin-universal"
+      when /^Linux aarch64/ ; "linux-arm64"
       when /^Linux.*64/ ; "linux-amd64"
       when /^FreeBSD.*64/ ; "freebsd-amd64"
       else


### PR DESCRIPTION
Builds a binary for `linux-arm64`, to support ejson2env on AWS Graviton ARM instances.