### PR TITLE
use darwin-all binary on macs

### DIFF
--- a/rubygem/bin/ejson2env
+++ b/rubygem/bin/ejson2env
@@ -2,7 +2,7 @@
 platform = `uname -sm`
 
 dir = case platform
-      when /^Darwin/    ; "darwin-universal"
+      when /^Darwin/    ; "darwin-all"
       when /^Linux.*64/ ; "linux-amd64"
       when /^FreeBSD.*64/ ; "freebsd-amd64"
       else


### PR DESCRIPTION
GoReleaser produces a `darwin-all` binary instead of a `darwin-universal` binary.