### PR TITLE
Add option to export a portion of secrets

### DIFF
--- a/cmd/ejson2env/main.go
+++ b/cmd/ejson2env/main.go
@@ -38,6 +38,10 @@ func main() {
 			Name:  "quiet, q",
 			Usage: "Suppress export statement",
 		},
+		cli.StringSliceFlag{
+			Name:  "include, i",
+			Usage: "Export only a subset of environment variables",
+		},
 	}
 
 	app.Action = func(c *cli.Context) {
@@ -69,7 +73,7 @@ func main() {
 			fail(fmt.Errorf("no secrets.ejson filename passed"))
 		}
 
-		if err := ejson2env.ReadAndExportEnv(filename, keydir, userSuppliedPrivateKey, exportFunc); nil != err {
+		if err := ejson2env.ReadAndExportEnv(filename, keydir, userSuppliedPrivateKey, exportFunc, c.StringSlice("include")); nil != err {
 			fail(err)
 		}
 	}

--- a/man/ejson2env.1.ronn
+++ b/man/ejson2env.1.ronn
@@ -23,6 +23,10 @@ workflow example.
     If set, assumes that the key that decrypts the passed ejson file was 
     passed in on standard input.
 
+  * `--include`=<key>:
+    If set, include in the output only the specified key(s). Can be provided
+    more than once.
+
 ## WORKFLOW
 
 ### 1: Add environment variables to an ejson file

--- a/secrets_test.go
+++ b/secrets_test.go
@@ -31,22 +31,31 @@ func TestReadAndExportEnv(t *testing.T) {
 	tests := []struct {
 		name           string
 		exportFunc     ExportFunction
+		include        []string
 		expectedOutput string
 	}{
 		{
 			name:           "ExportEnv",
 			exportFunc:     ExportEnv,
-			expectedOutput: "export test_key='test value'\n",
+			include:        make([]string, 0),
+			expectedOutput: "export test_key='test value'\nexport test_key_2='test value 2'\nexport test_key_3='test value 3'\n",
 		},
 		{
 			name:           "ExportQuiet",
 			exportFunc:     ExportQuiet,
-			expectedOutput: "test_key='test value'\n",
+			include:        make([]string, 0),
+			expectedOutput: "test_key='test value'\ntest_key_2='test value 2'\ntest_key_3='test value 3'\n",
+		},
+		{
+			name:           "ExportInclude",
+			exportFunc:     ExportEnv,
+			include:        []string{"test_key", "test_key_3"},
+			expectedOutput: "export test_key='test value'\nexport test_key_3='test value 3'\n",
 		},
 	}
 
 	for _, test := range tests {
-		err := ReadAndExportEnv("testdata/test-expected-usage.ejson", "./key", TestKeyValue, test.exportFunc)
+		err := ReadAndExportEnv("testdata/test-expected-usage.ejson", "./key", TestKeyValue, test.exportFunc, test.include)
 		if nil != err {
 			t.Errorf("testing %s failed: %s", test.name, err)
 			continue
@@ -72,7 +81,7 @@ func TestReadAndExportEnvWithBadEjson(t *testing.T) {
 		output = os.Stdout
 	}()
 
-	err = ReadAndExportEnv("bad.ejson", "./key", TestKeyValue, ExportEnv)
+	err = ReadAndExportEnv("bad.ejson", "./key", TestKeyValue, ExportEnv, make([]string, 0))
 	if nil == err {
 		t.Fatal("failed to fail when loading a broken ejson file")
 	}

--- a/testdata/test-expected-usage.ejson
+++ b/testdata/test-expected-usage.ejson
@@ -1,6 +1,8 @@
 {
     "_public_key": "795e671066eef17025c816b6d7c4f5c658b191cfaa31baca69963d761606415c",
     "environment": {
-        "test_key": "EJ[1:dgKp4cmFm42z8pfH/FJD8KRpaum5ZB6zACbuYvNFrGA=:wwS8w2C2Ihrg62M6E8H/G1Tt5gXocugo:Rv1qmluaq4HZHfr1lVtvAXxHrHsZSYio2wI=]"
+        "test_key": "EJ[1:dgKp4cmFm42z8pfH/FJD8KRpaum5ZB6zACbuYvNFrGA=:wwS8w2C2Ihrg62M6E8H/G1Tt5gXocugo:Rv1qmluaq4HZHfr1lVtvAXxHrHsZSYio2wI=]",
+        "test_key_2": "EJ[1:J2tLLU5iE4QqgzM1hOpK44jv8DhC8+1VYJGEh+2AJkE=:tRz/uG5NHkzRYmJ8+SUQMZxoMSO/gNR9:lnUJz70aqVT6Y3oQtybXHKDC88srWAhPbiqTuA==]",
+        "test_key_3": "EJ[1:CP6m/QOGqF4mXVzMrvuHtw9eFUq3OEJobv6AbjDgJWM=:l8rkRosxfPmzTOCdPPsC5arkwVzKj2PM:NGL6F62pADDuOfFOh6hfA2ObSYRVo1D4uMgrYQ==]"
     }
 }


### PR DESCRIPTION
This pull request adds a flag to ejson2env that enables exporting only a portion of the secrets as environment variables.

The partial export functionality is described in the [ejson readme](https://github.com/Shopify/ejson/blob/5ec268c04e6ff3b436d25c8d26df5e4d37992b89/README.md?plain=1#L29-L30) but I didn't find an obvious way to achieve it with the current state of the ejson2env CLI except for post-processing the CLI output which to me seems quite brittle.

If this change is merged, a consumer of ejson2env can request a subset of secrets to be exported as such:

```sh
ejson2env ./path/to/secrets.ejson \
  --include some_key \
  --include other_key
```

A concrete use-case which I have for the partial export functionality is that I have one shared secrets file which I use to inject values into Github Action workflows. However, some steps of the workflow require only access to some of the subsets of the secret values. Per the principle of least privilege, I want to only expose the secret values which each step requires, as opposed to exposing all the secret values to all the steps.