### PR TITLE
Add option to skip shell escaping

### DIFF
--- a/cmd/ejson2env/main.go
+++ b/cmd/ejson2env/main.go
@@ -38,6 +38,10 @@ func main() {
 			Name:  "quiet, q",
 			Usage: "Suppress export statement",
 		},
+		cli.BoolFlag{
+			Name:  "raw, r",
+			Usage: "Skip shell-escaping values",
+		},
 	}
 
 	app.Action = func(c *cli.Context) {
@@ -46,11 +50,15 @@ func main() {
 
 		keydir := c.String("keydir")
 		quiet := c.Bool("quiet")
+		raw := c.Bool("raw")
 
 		// select the ExportFunction to use
 		exportFunc := ejson2env.ExportEnv
 		if quiet {
 			exportFunc = ejson2env.ExportQuiet
+		}
+		if raw {
+			exportFunc = ejson2env.ExportRaw
 		}
 
 		if c.Bool("key-from-stdin") {

--- a/exportfunctions.go
+++ b/exportfunctions.go
@@ -22,3 +22,11 @@ func ExportQuiet(w io.Writer, values map[string]string) {
 		fmt.Fprintf(w, "%s=%s\n", key, shell.Escape(value))
 	}
 }
+
+// ExportRaw writes the passed environment values to the passed
+// io.Writer in %s=%s format without shell escaping.
+func ExportRaw(w io.Writer, values map[string]string) {
+	for key, value := range values {
+		fmt.Fprintf(w, "%s=%s\n", key, value)
+	}
+}

--- a/secrets_test.go
+++ b/secrets_test.go
@@ -43,6 +43,11 @@ func TestReadAndExportEnv(t *testing.T) {
 			exportFunc:     ExportQuiet,
 			expectedOutput: "test_key='test value'\n",
 		},
+		{
+			name:           "ExportRaw",
+			exportFunc:     ExportRaw,
+			expectedOutput: "test_key=test value\n",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This pull request adds a flag `--raw` to skip shell escaping the values that are being output. The use-case I have for this flag is two-fold:

1. The current escaping is quite aggressive and adds quotes in scenarios where they're not strictly necessary (e.g. `export FOO=bar+baz` works fine but currently gets escaped); adding this flag means more predictable output in scenarios where the user knows that the secrets won't contain any shell-specific special characters.

2. More importantly adding this flag means that ejson2env can now be used on Github Actions to set environment variables ([docs](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable)) via `ejson2env --raw path/to/secrets.ejson >> "${GITHUB_ENV}"`. Before this PR, this approach wouldn't work as Github Actions doesn't interpret escape characters.