### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Get latest Go version
         id: gover
-        run: echo ::set-output name=goversion::$(awk -F':|-' '/^FROM golang/ {print $2}' Dockerfile)
+        run: echo goversion=$(awk -F':|-' '/^FROM golang/ {print $2}' Dockerfile) >> "$GITHUB_OUTPUT"
       - name: Setup go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
       - name: Get latest Go version
         id: gover
-        run: echo ::set-output name=goversion::$(awk -F':|-' '/^FROM golang/ {print $2}' Dockerfile)
+        run: echo goversion=$(awk -F':|-' '/^FROM golang/ {print $2}' Dockerfile) >> "$GITHUB_OUTPUT"
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
@@ -29,7 +29,7 @@ jobs:
           version=${GITHUB_REF#refs/tags/v*}
           mkdir -p tmp
           sed '/^# '$version'/,/^# /!d;//d;/^\s*$/d' CHANGELOG.md > tmp/release_changelog.md
-          echo ::set-output name=VERSION::$version
+          echo VERSION=$version >> "$GITHUB_OUTPUT"
       - name: Release
         uses: goreleaser/goreleaser-action@v2
         with:


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter