### PR TITLE
Add option to trim leading underscore

### DIFF
--- a/cmd/ejson2env/main.go
+++ b/cmd/ejson2env/main.go
@@ -38,6 +38,10 @@ func main() {
 			Name:  "quiet, q",
 			Usage: "Suppress export statement",
 		},
+		cli.BoolFlag{
+			Name:  "trim-underscore",
+			Usage: "Trim leading underscore from variable names",
+		},
 	}
 
 	app.Action = func(c *cli.Context) {
@@ -46,11 +50,16 @@ func main() {
 
 		keydir := c.String("keydir")
 		quiet := c.Bool("quiet")
+		trim_underscore := c.Bool("trim-underscore")
 
 		// select the ExportFunction to use
 		exportFunc := ejson2env.ExportEnv
 		if quiet {
 			exportFunc = ejson2env.ExportQuiet
+		}
+
+		if trim_underscore {
+			exportFunc = ejson2env.TrimLeadingUnderscoreExportWrapper(exportFunc)
 		}
 
 		if c.Bool("key-from-stdin") {

--- a/exportfunctions.go
+++ b/exportfunctions.go
@@ -3,6 +3,7 @@ package ejson2env
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/taskcluster/shell"
 )
@@ -20,5 +21,17 @@ func ExportEnv(w io.Writer, values map[string]string) {
 func ExportQuiet(w io.Writer, values map[string]string) {
 	for key, value := range values {
 		fmt.Fprintf(w, "%s=%s\n", key, shell.Escape(value))
+	}
+}
+
+func TrimLeadingUnderscoreExportWrapper(exportfunc ExportFunction) ExportFunction {
+	return func(w io.Writer, values map[string]string) {
+		newValues := make(map[string]string, len(values))
+
+		for key, value := range values {
+			newValues[strings.TrimLeft(key, "_")] = value
+		}
+
+		exportfunc(w, newValues)
 	}
 }

--- a/secrets_test.go
+++ b/secrets_test.go
@@ -31,22 +31,37 @@ func TestReadAndExportEnv(t *testing.T) {
 	tests := []struct {
 		name           string
 		exportFunc     ExportFunction
+		ejsonFile      string
 		expectedOutput string
 	}{
 		{
 			name:           "ExportEnv",
 			exportFunc:     ExportEnv,
+			ejsonFile:      "testdata/test-expected-usage.ejson",
 			expectedOutput: "export test_key='test value'\n",
 		},
 		{
 			name:           "ExportQuiet",
 			exportFunc:     ExportQuiet,
+			ejsonFile:      "testdata/test-expected-usage.ejson",
 			expectedOutput: "test_key='test value'\n",
+		},
+		{
+			name:           "ExportEnvTrimUnderscore",
+			exportFunc:     TrimLeadingUnderscoreExportWrapper(ExportEnv),
+			ejsonFile:      "testdata/test-leading-underscore-env-key.ejson",
+			expectedOutput: "export test_key='test value'\n",
+		},
+		{
+			name:           "ExportEnvNoTrimUnderscore",
+			exportFunc:     ExportEnv,
+			ejsonFile:      "testdata/test-leading-underscore-env-key.ejson",
+			expectedOutput: "export _test_key='test value'\n",
 		},
 	}
 
 	for _, test := range tests {
-		err := ReadAndExportEnv("testdata/test-expected-usage.ejson", "./key", TestKeyValue, test.exportFunc)
+		err := ReadAndExportEnv(test.ejsonFile, "./key", TestKeyValue, test.exportFunc)
 		if nil != err {
 			t.Errorf("testing %s failed: %s", test.name, err)
 			continue


### PR DESCRIPTION
Keys with unencrypted values have a leading underscore. When exported to an env variable the underscore is preserved but can feel awkward to use on the system.

The new `--trim-underscore` flag is introduced and can be used to, you guessed it, trim the underscore from the exported env variable name.

The use of this flag makes `ejson2env` match Krane's [behaviour](https://github.com/shopify/krane?tab=readme-ov-file#deploying-kubernetes-secrets-from-ejson) of stripping the leading understore from secrets.

Fixes #17