### PR TITLE
Enable CI workflow on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: push
+on: [push, pull_request]
 
 permissions:
   contents: read


### PR DESCRIPTION
The `push` event only triggers for commits to this repo and will not run on commits in a PR from a forked repo. This becomes an issue since CI is required to merge a PR.