### PR TITLE
release.sh: correct paths output by goreleaser

### DIFF
--- a/rubygem/build.sh
+++ b/rubygem/build.sh
@@ -3,9 +3,9 @@ set -e
 mkdir -p rubygem/build/linux-amd64
 mkdir -p rubygem/build/darwin-all
 mkdir -p rubygem/build/freebsd-amd64
-cp dist/ejson2env_linux_amd64/ejson2env rubygem/build/linux-amd64/ejson2env
+cp dist/ejson2env_linux_amd64_v1/ejson2env rubygem/build/linux-amd64/ejson2env
 cp dist/ejson2env_darwin_all/ejson2env rubygem/build/darwin-all/ejson2env
-cp dist/ejson2env_freebsd_amd64/ejson2env rubygem/build/freebsd-amd64/ejson2env
+cp dist/ejson2env_freebsd_amd64_v1/ejson2env rubygem/build/freebsd-amd64/ejson2env
 cp LICENSE.txt rubygem/LICENSE.txt
 bundle install
 mkdir -p rubygem/lib/ejson2env


### PR DESCRIPTION
In https://github.com/Shopify/ejson2env/actions/runs/15164326353/job/42639965570, we observe the build failing

```
cp: cannot stat 'dist/ejson2env_linux_amd64/ejson2env': No such file or directory
```

Earlier in the same build log, we can see the actual paths output by goreleaser, that this step is trying to reuse:

```
  • building binaries
    • building                                       binary=dist/ejson2env_freebsd_arm64/ejson2env
    • building                                       binary=dist/ejson2env_linux_amd64_v1/ejson2env
    • building                                       binary=dist/ejson2env_linux_arm64/ejson2env
    • building                                       binary=dist/ejson2env_freebsd_amd64_v1/ejson2env
    • building                                       binary=dist/ejson2env_darwin_amd64_v1/ejson2env
    • building                                       binary=dist/ejson2env_darwin_arm64/ejson2env
    • took: 35s
  • universal binaries
    • creating from 2 binaries                       id=ejson2env binary=dist/ejson2env_darwin_all/ejson2env`
```

This updates the script to use the paths that goreleaser outputs.

