### PR TITLE
gemspec: require MFA

### DIFF
--- a/rubygem/ejson2env.gemspec
+++ b/rubygem/ejson2env.gemspec
@@ -17,4 +17,5 @@ Gem::Specification.new do |spec|
   spec.executables   = ["ejson2env"]
   spec.test_files    = []
   spec.require_paths = ["lib"]
+  spec.metadata["rubygems_mfa_required"] = "true"
 end


### PR DESCRIPTION
This metadata makes Rubygems reject pushes that do not use MFA.

We obviously use MFA when publishing, but this metadata allows other users of the gem to _confirm_ that we do.

It's pretty common - https://github.com/search?q=path%3A.gemspec%20%2Frubygems_mfa_required%2F&type=code

# Related

- Discovered #101 